### PR TITLE
Enable MinIO and Mimir metrics and configure Alloy for scraping

### DIFF
--- a/templates/monitoring/mimir.yaml
+++ b/templates/monitoring/mimir.yaml
@@ -36,6 +36,10 @@ spec:
             replicas: 1
             allocatedMemory: 1024
 
+          metaMonitoring:
+            serviceMonitor:
+              enabled: true
+
           index-cache:
             enabled: true
             replicas: 3

--- a/templates/storage/minio.yaml
+++ b/templates/storage/minio.yaml
@@ -20,6 +20,8 @@ spec:
               existingSecret: true
               accessKey:
               secretKey:
+            metrics:
+              enabled: true
             buckets:
               - name: mimir-blocks
               - name: mimir-alertmanager
@@ -29,6 +31,11 @@ spec:
                 name: pool-0
                 size: 25Gi
                 volumesPerServer: 4
+            poolsMetadata:
+              annotations:
+                prometheus.io/scrape: "true"
+                prometheus.io/path: "/minio/v2/metrics/cluster"
+                prometheus.io/port: "9000"
             certificate:
               requestAutoCert: false
               externalCertSecret:


### PR DESCRIPTION
This change enables the metrics endpoints for MinIO and Mimir and configures Alloy to scrape these metrics.

For MinIO:
- Enabled the built-in metrics endpoint (`/minio/v2/metrics/cluster` on port 9000) by setting `tenant.metrics.enabled = true` in the MinIO Helm chart values.
- Added Prometheus scraping annotations (`prometheus.io/scrape`, `prometheus.io/path`, `prometheus.io/port`) to the MinIO tenant pods to allow Alloy to discover and scrape them.

For Mimir:
- Enabled the ServiceMonitor by setting `metaMonitoring.serviceMonitor.enabled = true` in the Mimir Helm chart values. Alloy is already configured to discover and scrape ServiceMonitors.

These changes will allow metrics data from MinIO and Mimir to be collected by Alloy.